### PR TITLE
remove .bin from gitignore so spacy files can be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ __pycache__
 .venv
 .vscode
 *.egg-info
-*.bin
 *.log
 *.pyc
 *.zip

--- a/shared/sentence-transformer/distilbert-base-nli-mean-tokens/0_Transformer/pytorch_model.bin
+++ b/shared/sentence-transformer/distilbert-base-nli-mean-tokens/0_Transformer/pytorch_model.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9e7b802522b2d4b325f63b31af293b3f5f7a00515b342176c3ee9aa4fee807d
+size 265473819

--- a/shared/spacy-model/en_core_web_sm-3.1.0/en_core_web_sm/en_core_web_sm-3.1.0/lemmatizer/lookups/lookups.bin
+++ b/shared/spacy-model/en_core_web_sm-3.1.0/en_core_web_sm/en_core_web_sm-3.1.0/lemmatizer/lookups/lookups.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb64f40c0f8396d1762730c0ddf4dad2a52d138f5a389f71a1a1d088173b7737
+size 972893

--- a/shared/spacy-model/en_core_web_sm-3.1.0/en_core_web_sm/en_core_web_sm-3.1.0/vocab/lookups.bin
+++ b/shared/spacy-model/en_core_web_sm-3.1.0/en_core_web_sm/en_core_web_sm-3.1.0/vocab/lookups.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ddd140ecac6a8c4592e9146d6e30074569ffaed97ee51edc9587dc510f8934c
+size 69982


### PR DESCRIPTION
There are .bin files in the /shared/ directory that are needed for train and followup to work properly. The /shared/ directory is copied into the docker images when they are built.