### PR TITLE
threading used to make sbert requests concurrently

### DIFF
--- a/module/classifier/ner.py
+++ b/module/classifier/ner.py
@@ -173,7 +173,6 @@ class NamedEntities:
         if lemma in self.pop_culture:
             ent.weight = ent.weight - (1 - ent.cos_sim_weight)
 
-    # TODO: this function should be called once, when all entites are setup in the class already.
     def populate_entities_sim_weights(self, all_answered: List[AnswerInfo]) -> None:
         entity_vals = self.people.copy()
         entity_vals.update(self.acronyms)


### PR DESCRIPTION
When follow-ups are requested: query SBERT for the cos sim weight for all entities at the start using threads, instead of requesting them lazily.

Large requests went from 10.5 seconds -> 3.5 seconds